### PR TITLE
Update the maintainer list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,7 +10,7 @@ Maintainership is on a per project basis.
   - Alberto Ricart <alberto@nats.io> [@aricart](https://github.com/aricart)
   - Waldemar Quevedo <wally@nats.io> [@wallyqs](https://github.com/wallyqs)
   - Colin Sullivan <colin@nats.io> [@ColinSullivan1](https://github.com/ColinSullivan1)
-  - Stephen Asubry [@sasbury](https://github.com/sasbury) 
+  - Stephen Asbury [@sasbury](https://github.com/sasbury) 
 
 ### Maintainers
   - R.I. Pienaar <rip@devco.net> [@ripienaar](https://github.com/ripienaar)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,9 +1,21 @@
 # Maintainers
 Maintainership is on a per project basis.
 
-
 ### Core-maintainers
+  - Derek Collison <derek@nats.io> [derekcollison](https://github.com/derekcollison)
+  - Ginger Collison <ginger@nats.io> [gcolliso](https://github.com/gcolliso)
+  - David Kemper <djk@nats.io> [@davidkemper](https://github.com/davidkemper)
+  - Ivan Kozlovic <ivan@nats.io> [@kozlovic](https://github.com/kozlovic)
+  - Jaime Pina <jaime@nats.io> [@variadico](https://https://github.com/variadico)
+  - Alberto Ricart <alberto@nats.io> [@aricart](https://github.com/aricart)
+  - Waldemar Quevedo <wally@nats.io> [@wallyqs](https://github.com/wallyqs)
+  - Colin Sullivan <colin@nats.io> [@ColinSullivan1](https://github.com/ColinSullivan1)
+  - Stephen Asubry [@sasbury](https://github.com/sasbury) 
 
-  - [ColinSullivan1](https://github.com/ColinSullivan1)
-  - [derekcollison](https://github.com/derekcollison)
-  - [gcolliso](https://github.com/gcolliso)
+### Maintainers
+  - R.I. Pienaar <rip@devco.net> [@ripienaar](https://github.com/ripienaar)
+  - Paulo Pires [@pires](https://github.com/pires)  
+  - Oleg Shaldybin <olegsh@google.com> [@olegshaldibin](https://github.com/olegshaldibin)
+  - Brian Shannan <brianshannan@gmail.com> [@brianshannan](https://github.com/brianshannan)
+  - Charlie Strawn <cdstrawn@gmail.com> [@charliestrawn](https://github.com/charliestrawn)
+  - Christopher Watford <christopher.watford@ge.com> [@watfordgnf](https://github.com/watfordgnf)


### PR DESCRIPTION
This includes everyone to be used as a public reference.

Signed-off-by: Colin Sullivan <colin@synadia.com>