### PR TITLE
Remove Jaime as NATS maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,7 +13,6 @@ Current list of NATS Organization Maintainers. Maintainership is on a per projec
   - Phil Pennock <pdp@nats.io> [@philpennock](https://github.com/philpennock)
   - R.I. Pienaar <rip@devco.net> [@ripienaar](https://github.com/ripienaar)
   - Tomasz Pietrek <tomasz@nats.io> [@jarema](https://github.com/jarema)
-  - Jaime Pina <jaime@variadi.co> [@variadico](https://github.com/variadico)
   - Paulo Pires [@pires](https://github.com/pires)
   - Waldemar Quevedo <wally@nats.io> [@wallyqs](https://github.com/wallyqs)
   - Alberto Ricart <alberto@nats.io> [@aricart](https://github.com/aricart)


### PR DESCRIPTION
Jaime has left Synadia and relinquished his seat as a NATS maintainer.